### PR TITLE
Fix useEffect and object binding

### DIFF
--- a/components/prescription-form.tsx
+++ b/components/prescription-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -46,6 +46,18 @@ export default function PrescriptionForm() {
 
   const [isLoading, setIsLoading] = useState(false)
   const [savedPrescriptionId, setSavedPrescriptionId] = useState<string | null>(null)
+
+  // Persist the latest saved data so the print page can retrieve it
+  useEffect(() => {
+    if (savedPrescriptionId) {
+      try {
+        const payload = { prescription, medicines }
+        sessionStorage.setItem(`prescription:${savedPrescriptionId}`, JSON.stringify(payload))
+      } catch (err) {
+        // no-op if storage is unavailable
+      }
+    }
+  }, [savedPrescriptionId, prescription, medicines])
 
   const addMedicine = () => {
     setMedicines([
@@ -147,7 +159,7 @@ export default function PrescriptionForm() {
 
   const printPrescription = () => {
     if (savedPrescriptionId) {
-        window.open(`/prescription/print/${savedPrescriptionId}? patient_name=${prescription.patient_name} &patient_age=${prescription.patient_age} &patient_sex=${prescription.patient_sex} &patient_weight=${prescription.patient_weight} &patient_contact=${prescription.patient_contact} &patient_address=${prescription.patient_address} &allergies=${prescription.allergies} &symptoms=${prescription.symptoms} &findings=${prescription.findings} &diagnosis=${prescription.diagnosis} &medicines=${medicines}`, "_blank")
+      window.open(`/prescription/print/${savedPrescriptionId}`, "_blank")
     } else {
       toast({
         title: "Save Required",
@@ -367,7 +379,7 @@ export default function PrescriptionForm() {
                     <SelectContent>
                       {COMMON_MEDICINES.map((med) => (
                         <SelectItem key={med} value={med}>
-                          {med} dsfdsf
+                          {med}
                         </SelectItem>
                       ))}
                     </SelectContent>


### PR DESCRIPTION
Persist prescription data using `useEffect` for print page retrieval, correct the print URL's malformed query string, and remove stray text from the medicine dropdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-2efc6fb2-630e-4723-ab8f-46b9be2fd132">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2efc6fb2-630e-4723-ab8f-46b9be2fd132">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

